### PR TITLE
【検討Item:5】パラメータセットが複数ある場合の優先度、決定ルールなどの整理

### DIFF
--- a/v6mig-prov.txt
+++ b/v6mig-prov.txt
@@ -232,7 +232,6 @@ CPE は、JSON オブジェクトの未知のキーは無視してよい(MAY)。
 
 {
   "IP4OV6ProvisioningConfig": {
-    "IP4OV6Method": "MAP-E",
     "IP4OV6ServiceProviderName": "A VNE",
     "IP4OV6VNEServiceName": "Highspeed 4over6",
     "IP4OV6ISPServiceName": "ISP-A",
@@ -302,15 +301,6 @@ Object Value
 IP4OV6ProvisioningConfig
   IPv4 over IPv6プロビジョニングデータ（グループ)
 　
-IP4OV6Method
-  MAP-E : MAP-Eを使用
-  MAP-T : MAP-Tを使用
-  DS-Lite : DS-Liteを使用
-  LW4o6 : Lightweight IPv4 over IPv6を使用
-  464XLAT : 464XLATを使用
-  IPv6-Only : IPv4 over IPv6サービス未サポート ※IPv6 Nativeでのインター
-  ネットサービス使用時のみ。他のIPv4 over IPv6サービスがある場合は、使用禁止
-
 IP4OV6ServiceProviderName
   NGN上でのサービスではVNE名
   JPNE, IMF, NTTコミュニケーションズ, Biglobe等 NGN以外でのサービスではISP名
@@ -330,7 +320,16 @@ IP4OV6ISPTTL
   TTL : プロビ情報の有効期間。単位は秒。
 　
 PriorityConfig
-  優先度設定
+  マイグレーション方式を優先度順に並べたもの。プロビジョニングデータに複数
+  の方式が記述されている場合、CPE は PriorityConfig に記述された順序で各方
+  式の利用を試みる。
+
+  マイグレーション方式には以下の文字列のいずれかを指定する。
+
+    "MAP-E", "MAP-T", "DS-Lite", "LW4o6", "464XLAT", "IPIP"
+
+  なお、CPE は、PriorityConfig の設定によらずユーザが固定的に設定できるモー
+  ドを備えることが望ましい。
 
 MAP-E
   MAP-Eプロビジョニングデータ(グループ)


### PR DESCRIPTION
プロビジョニングデータには複数の接続方式を書くことができる。その場合、CPE は IP4OV6Method で指定されたひとつのみを選んで接続する。しかし、ISP は複数の方式を優先度付きで提示したい場合があるため、新しい "PriorityConfig" パラメタを追加して表現する。PriorityConfig の表現形式は、方式名の string を array で優先度順に並べたものとする。

IP4OV6Method の意図は PriorityConfig で表現できるため、IP4OV6Method は削除する。

また PriorityConfig で提示される値によらずユーザが固定的に設定する余地を残すべきであるため、それを明記した。

参考 [v6mig-prov : 49][v6mig-prov : 52][v6mig-prov : 55][v6mig-prov : 70]
