### PR TITLE
DS-LiteAFTRFQDN と DS-LiteAFTRAddress をひとつにまとめる。

### DIFF
--- a/v6mig-prov.txt
+++ b/v6mig-prov.txt
@@ -255,8 +255,7 @@ CPE は、JSON オブジェクトの未知のキーは無視してよい(MAY)。
       ]
     },
     "DS-Lite": {
-      "DS-LiteAFTRFQDN": "aftr.example.net",
-      "DS-LiteAFTRAddress": "2001:db8:2::1"
+      "aftr": "aftr.example.net"
     },
     "LW4o6": {
       "LW4o6Rules": {
@@ -376,12 +375,9 @@ MAP-EPSIDOffset
 DS-Lite
   DS-Lite プロビジョニングデータ(グループ)
 　
-DS-LiteAFTRFQDN
-  DS-Lite AFTR の FQDN
-　
-DS-LiteAFTRAddress
-  DS-Lite AFTR アドレス
-　
+aftr
+  DS-Lite AFTR の DNS 名もしくは IPv6 アドレス。
+
 LW4o6
   lw4o6プロビジョニングデータ(グループ)
 　


### PR DESCRIPTION
DS-Lite の AFTR を指定する方法は、1. DNS の FQDN を書く、2. IPv6 アドレスで書く、の二通りあり、パラメタが分かれている。しかし、そのどちらであるかは内容を見れば CPE 自身で判断できるため、ひとつにまとめて単純にしたい。